### PR TITLE
Component Supplier Should Return a Date Field for Dates

### DIFF
--- a/source/Willow-Bootstrap/BootstrapComponentSupplier.class.st
+++ b/source/Willow-Bootstrap/BootstrapComponentSupplier.class.st
@@ -84,7 +84,7 @@ BootstrapComponentSupplier >> checkboxUnlabeledOnModel: anObjectToUseWhenOn offM
 { #category : #Supplying }
 BootstrapComponentSupplier >> dateFieldApplying: aComponentCommand [
 
-	^ self singleLineTextFieldApplying: [ :field | (field setMaximumLengthTo: 10) + aComponentCommand + BootstrapDatepickerCommand new ]
+	^ DateFieldWebView applying: [ :field | (field setMaximumLengthTo: 10) + aComponentCommand + BootstrapDatepickerCommand new ]
 ]
 
 { #category : #Supplying }


### PR DESCRIPTION
Previously, `dateFieldApplying:` returned either a `TextFieldWebView` or a `DateFieldWebView` depending on the component supplier, thus you could not depend on its API which seems to invalidate the point of having a custom DateView. One could query the `#date` if using HTML5 but not Bootstrap