### PR TITLE
Fixes due to changes in ba-st/Willow#129

### DIFF
--- a/source/BaselineOfWillowBootstrap/BaselineOfWillowBootstrap.class.st
+++ b/source/BaselineOfWillowBootstrap/BaselineOfWillowBootstrap.class.st
@@ -36,7 +36,7 @@ BaselineOfWillowBootstrap >> setUpDependencies: spec [
 	spec
 		baseline: 'Willow'
 			with: [ spec
-				repository: 'github://ba-st/Willow:v10/source';
+				repository: 'github://ba-st/Willow:v11/source';
 				loads: #('Willow') ];
 		project: 'Willow-Tests' copyFrom: 'Willow' with: [ spec loads: #('Willow-Tests') ]
 

--- a/source/Willow-Bootstrap-Tests/BootstrapComponentSupplierTest.class.st
+++ b/source/Willow-Bootstrap-Tests/BootstrapComponentSupplierTest.class.st
@@ -4,7 +4,7 @@ A BootstrapComponentSupplierTest is a test class for testing the behavior of Boo
 Class {
 	#name : #BootstrapComponentSupplierTest,
 	#superclass : #WARenderingTest,
-	#category : 'Willow-Bootstrap-Tests-Frontend'
+	#category : #'Willow-Bootstrap-Tests-Frontend'
 }
 
 { #category : #private }
@@ -74,7 +74,7 @@ BootstrapComponentSupplierTest >> testDateFieldApplying [
 
 	self
 		assertRenderingOf: [ :supplier | supplier dateFieldApplying: [ :field | field addClass bootstrap textCenter ] ]
-		equals: '<input value="" name="1" class="form-control text-center" maxlength="10" data-provide="datepicker" type="text"/>'
+		equals: '<input value="" name="1" type="text" class="form-control text-center" maxlength="10" data-provide="datepicker"/>'
 ]
 
 { #category : #'tests-Supplying' }

--- a/source/Willow-Bootstrap-Tests/WillowExtensionsTest.class.st
+++ b/source/Willow-Bootstrap-Tests/WillowExtensionsTest.class.st
@@ -33,6 +33,12 @@ WillowExtensionsTest >> assertRenderingOfDivApplying: aCommand equals: anExpecte
 ]
 
 { #category : #tests }
+WillowExtensionsTest >> testBootstrapClassification [
+
+	self assert: ReflectiveCascadingStyleSheetBuilder new bootstrap >> #textCenter equals: 'text-center'
+]
+
+{ #category : #tests }
 WillowExtensionsTest >> testBootstrapClassificationCommandBuilder [
 
 	(Classification >> #bootstrap) names

--- a/source/Willow-Bootstrap/BootstrapComponentSupplier.class.st
+++ b/source/Willow-Bootstrap/BootstrapComponentSupplier.class.st
@@ -83,8 +83,9 @@ BootstrapComponentSupplier >> checkboxUnlabeledOnModel: anObjectToUseWhenOn offM
 
 { #category : #Supplying }
 BootstrapComponentSupplier >> dateFieldApplying: aComponentCommand [
-
-	^ self singleLineTextFieldApplying: [ :field | (field setMaximumLengthTo: 10) + aComponentCommand + BootstrapDatepickerCommand new ]
+	
+	"The datepicker plugin don't plays nice with the HTML5 date input, so we use text input"
+	^ DateFieldWebView applying: [ :field | field addClass bootstrap formControl + (field setMaximumLengthTo: 10) + aComponentCommand + BootstrapDatepickerCommand new + field beTextInput ]
 ]
 
 { #category : #Supplying }

--- a/source/Willow-Bootstrap/BootstrapComponentSupplier.class.st
+++ b/source/Willow-Bootstrap/BootstrapComponentSupplier.class.st
@@ -84,7 +84,7 @@ BootstrapComponentSupplier >> checkboxUnlabeledOnModel: anObjectToUseWhenOn offM
 { #category : #Supplying }
 BootstrapComponentSupplier >> dateFieldApplying: aComponentCommand [
 	
-	"The datepicker plugin don't plays nice with the HTML5 date input, so we use text input"
+	"The datepicker plugin doesn't play nice with the HTML5 date input, so we use a text input instead."
 	^ DateFieldWebView applying: [ :field | field addClass bootstrap formControl + (field setMaximumLengthTo: 10) + aComponentCommand + BootstrapDatepickerCommand new + field beTextInput ]
 ]
 


### PR DESCRIPTION
Merge after ba-st/Willow#130 is merged and v11 released.
Changes due to ba-st/Willow#129
Makes the view returned by `dateFieldApplying:` polymorphic with the HTML5 supplied. 